### PR TITLE
カレンダーにGoogleカレンダーの日本の祝日データを表示

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,5 @@
 //= require turbolinks
 //= require moment
 //= require fullcalendar
+//= require fullcalendar/gcal.js
 //= require_tree .

--- a/app/assets/javascripts/calendar.coffee
+++ b/app/assets/javascripts/calendar.coffee
@@ -1,9 +1,24 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+# デフォルト表示（javascriptの書き方）
 #$(document).ready(function() {
     #$('#calendar').fullCalendar({
     #})
 #});
+
+# デフォルト表示（coffeecriptの書き方）
+#$(document).ready ->
+    #$('#calendar').fullCalendar({})
+
+# 日本の祝日表示（coffeecriptの書き方）
 $(document).ready ->
-    $('#calendar').fullCalendar({})
+    $('#calendar').fullCalendar({#
+        #'<YOUR API KEY>',
+        googleCalendarApiKey: 'AIzaSyCGtyHc6rdZk4BOKg8TpLuAhJKOnQnD2MI',
+        events: {
+            googleCalendarId: 'ja.japanese#holiday@group.v.calendar.google.com',
+            className: 'gcal-event'
+        }
+    })


### PR DESCRIPTION
Fullcalendarのカレンダー表示にGoogleカレンダーの日本の祝日データを表示するようにしました。
まだプロトタイプ的な実装、表示ですが。

jsでやっていてフロント側にAPIキーとか出ているのがちょっと嫌なので別issueで外部データ取得系はサーバーサイドで隠蔽しておきたいと思ってます。

@jTaro 