### PR TITLE
カレンダーのcssのうち、web画面に不要となるprint.cssファイルの読み込みを削除。

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,7 +11,6 @@
  * file per style scope.
  *
  *= require fullcalendar
- *= require fullcalendar.print
  *= require_tree .
  *= require_self
  */

--- a/log/development.log
+++ b/log/development.log
@@ -1,205 +1,241 @@
 
 
-Started GET "/" for 49.239.64.12 at 2015-08-11 10:12:04 +0000
-Cannot render console from 49.239.64.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (2.3ms)
-Completed 200 OK in 21ms (Views: 10.7ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/" for 49.239.64.12 at 2015-08-11 10:12:53 +0000
-Cannot render console from 49.239.64.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (2.0ms)
-Completed 200 OK in 19ms (Views: 9.3ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/" for 49.239.64.12 at 2015-08-11 10:31:57 +0000
-Cannot render console from 49.239.64.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (2.8ms)
-Completed 200 OK in 29ms (Views: 15.2ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/rails/info/properties" for 49.239.64.12 at 2015-08-11 10:34:37 +0000
-Cannot render console from 49.239.64.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::InfoController#properties as */*
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/info/properties.html.erb (0.8ms)
-Completed 200 OK in 63ms (Views: 27.9ms | ActiveRecord: 2.1ms)
-
-
-Started GET "/" for 49.239.64.12 at 2015-08-11 10:39:46 +0000
-Cannot render console from 49.239.64.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (0.1ms)
-Completed 200 OK in 3ms (Views: 2.5ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/" for 202.215.67.12 at 2015-08-19 14:44:49 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (2.1ms)
-Completed 200 OK in 25ms (Views: 14.5ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/" for 202.215.67.12 at 2015-08-28 16:59:09 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (2.9ms)
-Completed 200 OK in 32ms (Views: 17.0ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:00:24 +0000
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:46:18 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.5ms)
-Completed 200 OK in 2297ms (Views: 2295.4ms | ActiveRecord: 0.0ms)
+  Rendered calendar/index.html.erb within layouts/application (2.2ms)
+Completed 200 OK in 430ms (Views: 416.5ms | ActiveRecord: 0.0ms)
 
 
-Started GET "/assets/fullcalendar.self-bfd1e733800d14d6124c551399fa09d9fb4108c7623ad7bd2cf351ef92704af5.css?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
+Started GET "/assets/application.self-44dc72337fbefc4f8c73fc8781b922cf9e4f99f8d068e6563c3820851d9390f6.js?body=1" for 202.215.67.12 at 2015-09-02 15:46:18 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 
-Started GET "/assets/fullcalendar.print.self-73e61e7a8213cf0d9c36c38be7477454f6862ad7f15d7394fb5ab7a8c6c60197.css?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
+Started GET "/assets/calendar.self-63a04b60f64d6962a38ad46f76d64ad20cf24f98ed9cc688e1144aeaa1ff2cef.js?body=1" for 202.215.67.12 at 2015-09-02 15:46:18 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 
-Started GET "/assets/calendar.self-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:46:18 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
-
-Started GET "/assets/application.self-167193cd81d9330d9ddb5c4ec7b44214fea529aa8a94f3a86e6526e4f652fc02.css?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/assets/jquery.self-d03a5518f45df77341bdbe6201ba3bfa547ebba8ed64f0ea56bfa5f96ea7c074.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/assets/jquery_ujs.self-8e98a7a072a6cee1372d19fff9ff3e6aa1e39a37d89d6f06861637d061113ee7.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/assets/turbolinks.self-c37727e9bd6b2735da5c311aa83fead54ed0be6cc8bd9a65309e9c5abe2cbfff.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/assets/moment.self-7c169710367e715cec0e7768bb92b9339f5a767a109041e9e9861a0abc0afa44.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/assets/fullcalendar.self-8668c2e6be32331fb05b9c8cb047adeb64ae3d0575ba9d2f029b9a4cb37ec3f5.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/assets/calendar.self-877aef30ae1b040ab8a3aba4e3e309a11d7f2612f44dde450b5c157aa5f95c05.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
 
 
-Started GET "/assets/application.self-7862a8a8b42407b4741a1adeeea35f0d13ddc4f702ec532adb0674491d296495.js?body=1" for 202.215.67.12 at 2015-08-28 17:00:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.7ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (15.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (3.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (81.0ms)
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:01:40 +0000
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:50:46 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 500 Internal Server Error in 209ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    3: <head>
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    6:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    7:   <%= csrf_meta_tags %>
-    8: </head>
-    9: <body>
-  app/views/layouts/application.html.erb:6:in `_app_views_layouts_application_html_erb___2419489584438626751_50840560'
+Completed 200 OK in 187ms (Views: 186.1ms | ActiveRecord: 0.0ms)
 
 
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (10.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (4.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.5ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (48.2ms)
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:50:47 +0000
+Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:04:11 +0000
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (6.0ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (3.1ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (4.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (12.8ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (91.1ms)
+
+
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:50:54 +0000
+Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Processing by CalendarController#index as HTML
+  Rendered calendar/index.html.erb within layouts/application (0.1ms)
+Completed 200 OK in 129ms (Views: 128.1ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:50:54 +0000
+Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
+
+
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.2ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.0ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.2ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (63.8ms)
+
+
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:50:56 +0000
+Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Processing by CalendarController#index as HTML
+  Rendered calendar/index.html.erb within layouts/application (0.1ms)
+Completed 200 OK in 213ms (Views: 211.8ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:50:57 +0000
+Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
+
+
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.8ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.6ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (61.8ms)
+
+
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:53:12 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (0.0ms)
-Completed 500 Internal Server Error in 203ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    3: <head>
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    6:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    7:   <%= csrf_meta_tags %>
-    8: </head>
-    9: <body>
-  app/views/layouts/application.html.erb:6:in `_app_views_layouts_application_html_erb___2419489584438626751_50840560'
+Completed 200 OK in 103ms (Views: 102.1ms | ActiveRecord: 0.0ms)
 
 
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (11.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (5.6ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (51.1ms)
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:53:12 +0000
+Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:07:18 +0000
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.5ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.7ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.2ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (52.3ms)
+
+
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:53:13 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 500 Internal Server Error in 163ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb___2419489584438626751_70221518763520'
+Completed 200 OK in 106ms (Views: 105.1ms | ActiveRecord: 0.0ms)
 
 
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (9.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (4.5ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.1ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (43.8ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:09:27 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 500 Internal Server Error in 186ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <!--<%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>-->
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb___2419489584438626751_70221517239500'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (11.8ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (4.6ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.1ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (50.9ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:10:01 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 200 OK in 323ms (Views: 322.3ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-28 17:10:02 +0000
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:53:13 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
@@ -230,24 +266,20 @@ ActionController::RoutingError (No route matches [GET] "/stylesheets/application
 
 
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.8ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.6ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (12.8ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (59.0ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.8ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.6ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (42.6ms)
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:11:01 +0000
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:53:15 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 200 OK in 351ms (Views: 349.9ms | ActiveRecord: 0.0ms)
+Completed 200 OK in 95ms (Views: 93.9ms | ActiveRecord: 0.0ms)
 
 
-Started GET "/assets/calendar.self-02d1c283476ffef52c220ff06912260a6a1cfa94c5b1e8bb9536d1924967209d.js?body=1" for 202.215.67.12 at 2015-08-28 17:11:01 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-28 17:11:01 +0000
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:53:16 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
@@ -278,43 +310,20 @@ ActionController::RoutingError (No route matches [GET] "/stylesheets/application
 
 
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.2ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.7ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.4ms)
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (44.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (46.5ms)
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:11:56 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.4ms)
-Completed 500 Internal Server Error in 212ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb___2419489584438626751_70221515090800'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (15.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (6.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (66.2ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:12:08 +0000
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:54:18 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (0.0ms)
-Completed 200 OK in 93ms (Views: 92.0ms | ActiveRecord: 0.0ms)
+Completed 200 OK in 118ms (Views: 116.6ms | ActiveRecord: 0.0ms)
 
 
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-28 17:12:08 +0000
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:54:19 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
@@ -345,164 +354,23 @@ ActionController::RoutingError (No route matches [GET] "/stylesheets/application
 
 
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.4ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.5ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.0ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.3ms)
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (59.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (64.0ms)
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:12:32 +0000
+Started GET "/" for 202.215.67.12 at 2015-09-02 15:57:50 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 200 OK in 82ms (Views: 81.3ms | ActiveRecord: 0.0ms)
+Completed 200 OK in 128ms (Views: 127.0ms | ActiveRecord: 0.0ms)
 
 
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-28 17:12:33 +0000
+Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-09-02 15:57:50 +0000
 Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
-  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
-  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
-  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
-  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
-  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
-  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
-  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
-  railties (4.2.1) lib/rails/engine.rb:518:in `call'
-  railties (4.2.1) lib/rails/application.rb:164:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
-  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.5ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (41.1ms)
-
-
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-28 17:12:46 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
-  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
-  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
-  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
-  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
-  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
-  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
-  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
-  railties (4.2.1) lib/rails/engine.rb:518:in `call'
-  railties (4.2.1) lib/rails/application.rb:164:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
-  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (46.3ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-28 17:13:58 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.0ms)
-Completed 500 Internal Server Error in 185ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb___2419489584438626751_70221515090800'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (10.1ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (5.1ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (44.9ms)
-
-
-Started GET "/" for 202.215.67.12 at 2015-08-29 07:53:53 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (3.9ms)
-Completed 200 OK in 43ms (Views: 20.9ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/calender/" for 202.215.67.12 at 2015-08-29 07:54:07 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-ActionController::RoutingError (No route matches [GET] "/calender"):
-  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
-  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
-  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
-  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
-  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
-  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
-  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
-  railties (4.2.1) lib/rails/engine.rb:518:in `call'
-  railties (4.2.1) lib/rails/application.rb:164:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
-  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.4ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (16.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.8ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (101.3ms)
-
-
-Started GET "/calendar/" for 202.215.67.12 at 2015-08-29 07:54:18 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-ActionController::RoutingError (No route matches [GET] "/calendar"):
   actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
   web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
   actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
@@ -530,131 +398,14 @@ ActionController::RoutingError (No route matches [GET] "/calendar"):
 
 
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.4ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (43.8ms)
-
-
-Started GET "/calendar/" for 202.215.67.12 at 2015-08-29 07:54:49 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-ActionController::RoutingError (No route matches [GET] "/calendar"):
-  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
-  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
-  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
-  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
-  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
-  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
-  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
-  railties (4.2.1) lib/rails/engine.rb:518:in `call'
-  railties (4.2.1) lib/rails/application.rb:164:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
-  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.4ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (3.1ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (87.8ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-29 07:55:16 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.5ms)
-Completed 500 Internal Server Error in 530ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb__3241386603769490741_36632200'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (14.3ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (10.1ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.4ms)
   Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (61.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (45.7ms)
 
 
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-29 07:59:31 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 500 Internal Server Error in 205ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:5:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb__3241386603769490741_36632200'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (9.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (41.1ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-29 08:00:25 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.1ms)
-Completed 500 Internal Server Error in 203ms (ActiveRecord: 0.0ms)
-
-ActionView::Template::Error (SyntaxError: [stdin]:4:19: reserved word 'function'):
-    4:   <title>Workspace</title>
-    5:   <%= stylesheet_link_tag "application-print", :media => "print" %>
-    6:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    7:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-    8:   <%= csrf_meta_tags %>
-    9: </head>
-   10: <body>
-  app/views/layouts/application.html.erb:7:in `_app_views_layouts_application_html_erb__3241386603769490741_36632200'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (9.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (41.9ms)
-
-
-Started GET "/calendar/index" for 202.215.67.12 at 2015-08-29 08:10:28 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.0ms)
-Completed 200 OK in 334ms (Views: 332.8ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/assets/calendar.self-3e8093170b5f5ab52a1ebfde735b57d4e7d2e62a5f1ed27a9782b55c45ffec7b.js?body=1" for 202.215.67.12 at 2015-08-29 08:10:29 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-29 08:10:29 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Started GET "/stylesheets/application-print.css" for 49.239.76.57 at 2015-09-03 10:31:00 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
   actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
@@ -683,99 +434,29 @@ ActionController::RoutingError (No route matches [GET] "/stylesheets/application
   /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
 
 
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.8ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (1.4ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (41.0ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (50.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (16.6ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (81.2ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (251.8ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (714.3ms)
 
 
-Started GET "/" for 202.215.67.12 at 2015-08-31 15:09:11 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::WelcomeController#index as HTML
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/welcome/index.html.erb (3.0ms)
-Completed 200 OK in 27ms (Views: 14.9ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/rails/info/properties" for 202.215.67.12 at 2015-08-31 15:13:51 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by Rails::InfoController#properties as */*
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/railties-4.2.1/lib/rails/templates/rails/info/properties.html.erb (0.6ms)
-Completed 200 OK in 70ms (Views: 22.1ms | ActiveRecord: 2.9ms)
-
-
-Started GET "/" for 202.215.67.12 at 2015-08-31 15:26:56 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-DEPRECATION WARNING: Defining a route where `to` is a controller without an action is deprecated. Please change `to: :calendar/index` to `controller: :calendar/index`. (called from block in <top (required)> at /home/ubuntu/workspace/config/routes.rb:9)
-
-ArgumentError (Missing :action key on routes definition, please check your routes.):
-  config/routes.rb:9:in `block in <top (required)>'
-  config/routes.rb:1:in `<top (required)>'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (4.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.9ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout (41.4ms)
-
-
-Started GET "/" for 202.215.67.12 at 2015-08-31 15:27:15 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-Processing by CalendarController#index as HTML
-  Rendered calendar/index.html.erb within layouts/application (0.3ms)
-Completed 200 OK in 353ms (Views: 352.2ms | ActiveRecord: 0.0ms)
-
-
-Started GET "/assets/calendar.self-3e8093170b5f5ab52a1ebfde735b57d4e7d2e62a5f1ed27a9782b55c45ffec7b.js?body=1" for 202.215.67.12 at 2015-08-31 15:27:15 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-31 15:27:15 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
-
-ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
-  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
-  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
-  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
-  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
-  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
-  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
-  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
-  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
-  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
-  railties (4.2.1) lib/rails/engine.rb:518:in `call'
-  railties (4.2.1) lib/rails/application.rb:164:in `call'
-  rack (1.6.1) lib/rack/lock.rb:17:in `call'
-  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
-  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
-  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
-
-
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.4ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (21.2ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (94.9ms)
-
-
-Started GET "/" for 202.215.67.12 at 2015-08-31 15:37:56 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Started GET "/" for 49.239.76.57 at 2015-09-03 12:02:22 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 Processing by CalendarController#index as HTML
   Rendered calendar/index.html.erb within layouts/application (2.4ms)
-Completed 200 OK in 260ms (Views: 246.6ms | ActiveRecord: 0.0ms)
+Completed 200 OK in 3732ms (Views: 3645.7ms | ActiveRecord: 0.0ms)
 
 
-Started GET "/stylesheets/application-print.css" for 202.215.67.12 at 2015-08-31 15:37:57 +0000
-Cannot render console from 202.215.67.12! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Started GET "/" for 49.239.76.57 at 2015-09-03 12:02:27 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Processing by CalendarController#index as HTML
+  Rendered calendar/index.html.erb within layouts/application (0.1ms)
+Completed 200 OK in 224ms (Views: 221.7ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/stylesheets/application-print.css" for 49.239.76.57 at 2015-09-03 12:02:27 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
 
 ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
   actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
@@ -804,8 +485,168 @@ ActionController::RoutingError (No route matches [GET] "/stylesheets/application
   /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
 
 
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.8ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (1.0ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (11.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.7ms)
-  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (67.1ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (8.5ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (2.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (4.4ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (4.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (69.6ms)
+
+
+Started GET "/" for 49.239.76.57 at 2015-09-03 14:19:48 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Processing by CalendarController#index as HTML
+  Rendered calendar/index.html.erb within layouts/application (0.1ms)
+Completed 200 OK in 142ms (Views: 138.5ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/stylesheets/application-print.css" for 49.239.76.57 at 2015-09-03 14:19:48 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
+
+
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (4.2ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (0.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (5.6ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (4.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (73.3ms)
+
+
+Started GET "/assets/fullcalendar.self-bfd1e733800d14d6124c551399fa09d9fb4108c7623ad7bd2cf351ef92704af5.css?body=1" for 49.239.76.57 at 2015-09-03 14:19:48 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/calendar.self-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css?body=1" for 49.239.76.57 at 2015-09-03 14:19:48 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/fullcalendar.print.self-73e61e7a8213cf0d9c36c38be7477454f6862ad7f15d7394fb5ab7a8c6c60197.css?body=1" for 49.239.76.57 at 2015-09-03 14:19:50 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/application.self-167193cd81d9330d9ddb5c4ec7b44214fea529aa8a94f3a86e6526e4f652fc02.css?body=1" for 49.239.76.57 at 2015-09-03 14:19:50 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/jquery_ujs.self-8e98a7a072a6cee1372d19fff9ff3e6aa1e39a37d89d6f06861637d061113ee7.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:50 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/jquery.self-d03a5518f45df77341bdbe6201ba3bfa547ebba8ed64f0ea56bfa5f96ea7c074.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:50 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/moment.self-7c169710367e715cec0e7768bb92b9339f5a767a109041e9e9861a0abc0afa44.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/turbolinks.self-c37727e9bd6b2735da5c311aa83fead54ed0be6cc8bd9a65309e9c5abe2cbfff.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/turbolinks.self-c37727e9bd6b2735da5c311aa83fead54ed0be6cc8bd9a65309e9c5abe2cbfff.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/calendar.self-63a04b60f64d6962a38ad46f76d64ad20cf24f98ed9cc688e1144aeaa1ff2cef.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/fullcalendar.self-8668c2e6be32331fb05b9c8cb047adeb64ae3d0575ba9d2f029b9a4cb37ec3f5.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/application.self-44dc72337fbefc4f8c73fc8781b922cf9e4f99f8d068e6563c3820851d9390f6.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/application.self-44dc72337fbefc4f8c73fc8781b922cf9e4f99f8d068e6563c3820851d9390f6.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/fullcalendar.self-8668c2e6be32331fb05b9c8cb047adeb64ae3d0575ba9d2f029b9a4cb37ec3f5.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/calendar.self-63a04b60f64d6962a38ad46f76d64ad20cf24f98ed9cc688e1144aeaa1ff2cef.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/fullcalendar/gcal.self-d487f2fad1e470ff40d3f8ce80b7c9f706df966b92fcb8ed67235a06787253d3.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/assets/fullcalendar/gcal.self-d487f2fad1e470ff40d3f8ce80b7c9f706df966b92fcb8ed67235a06787253d3.js?body=1" for 49.239.76.57 at 2015-09-03 14:19:51 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+
+Started GET "/" for 49.239.76.57 at 2015-09-03 14:25:28 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Processing by CalendarController#index as HTML
+  Rendered calendar/index.html.erb within layouts/application (0.1ms)
+Completed 200 OK in 242ms (Views: 241.3ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/stylesheets/application-print.css" for 49.239.76.57 at 2015-09-03 14:25:29 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+
+ActionController::RoutingError (No route matches [GET] "/stylesheets/application-print.css"):
+  actionpack (4.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
+  web-console (2.1.2) lib/web_console/middleware.rb:29:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
+  railties (4.2.1) lib/rails/rack/logger.rb:38:in `call_app'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `block in call'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:26:in `tagged'
+  activesupport (4.2.1) lib/active_support/tagged_logging.rb:68:in `tagged'
+  railties (4.2.1) lib/rails/rack/logger.rb:20:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
+  rack (1.6.1) lib/rack/methodoverride.rb:22:in `call'
+  rack (1.6.1) lib/rack/runtime.rb:18:in `call'
+  activesupport (4.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  actionpack (4.2.1) lib/action_dispatch/middleware/static.rb:113:in `call'
+  rack (1.6.1) lib/rack/sendfile.rb:113:in `call'
+  railties (4.2.1) lib/rails/engine.rb:518:in `call'
+  railties (4.2.1) lib/rails/application.rb:164:in `call'
+  rack (1.6.1) lib/rack/lock.rb:17:in `call'
+  rack (1.6.1) lib/rack/content_length.rb:15:in `call'
+  rack (1.6.1) lib/rack/handler/webrick.rb:89:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
+  /usr/local/rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
+
+
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (9.5ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_route.html.erb (3.3ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/routes/_table.html.erb (3.6ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (3.9ms)
+  Rendered /usr/local/rvm/gems/ruby-2.2.1/gems/actionpack-4.2.1/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (167.8ms)
+
+
+Started GET "/assets/application.self-d885a0a66bd595c10edb24f8879f94e334d88be0730c4d7c7a7b57c731c09037.css?body=1" for 49.239.76.57 at 2015-09-03 14:25:29 +0000
+Cannot render console from 49.239.76.57! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255


### PR DESCRIPTION
カレンダーの祝日データのデザインが想定していないスタイルになっていたのを解消。
@jTaro @IsseiT @AYAMUTO @kmoizumi どなたかレビューお願いします。