### PR TITLE
天気予報をアイコン化する

### DIFF
--- a/app/assets/javascripts/calendar.coffee
+++ b/app/assets/javascripts/calendar.coffee
@@ -38,6 +38,13 @@ $(document).ready ->
         ],
         lang: 'ja'
         height: 430
+        
+        eventRender: (events, element) ->
+    	    if events.img
+    	        $(element.context).css("border-color", "transparent")
+    	        $(element.context).css("background-color", "transparent")
+    	        $(element.context).html('<img class="photo" width="15px"  height="12px" src="' + events.img + '" />')
+
         # fullCalendarのイベントがすべて完了してからコールされる処理
         eventAfterAllRender: ->
             # ローディング表示を非表示に。

--- a/app/models/fullcalendar_event.rb
+++ b/app/models/fullcalendar_event.rb
@@ -9,6 +9,7 @@ class FullCalendarEvent
     :color,
     :backgroundColor,
     :borderColor,
-    :textColor
+    :textColor,
+    :img
    
 end

--- a/app/models/weather.rb
+++ b/app/models/weather.rb
@@ -19,6 +19,7 @@ class Weather
             event.title = w["telop"]
             event.start = w["date"]
             event.color = '#79b74a'
+            event.img = w["image"]["url"]
 
             events.push(event)
         end


### PR DESCRIPTION
ライブドア天気APIから取得したデータの中に天気アイコンのURLがある。
このURLの画像をカレンダーに表示する。

width,heightは固定です。